### PR TITLE
Update macOS runner to 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           path: build/allOutputs
 
   build-host:
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 11
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +51,7 @@ jobs:
           - os: windows-2019
             artifact-name: Win32
             architecture: x86
-          - os: macos-11
+          - os: macos-13
             artifact-name: macOS
             architecture: x64
     name: "Build - ${{ matrix.artifact-name }}"


### PR DESCRIPTION
macos-11 is going away
Define deployment target to 11 to maintain compatibility